### PR TITLE
分享文件列表根据分享时间排序而不应该是ID。

### DIFF
--- a/application/index/controller/Explore.php
+++ b/application/index/controller/Explore.php
@@ -35,7 +35,7 @@ class Explore extends Controller{
 		$list = Db::name('shares')
 				->where('type',"public")
 				->where('origin_name',"like","%".$keyWords."%")
-				->order('id DESC')
+				->order('share_time DESC')
 				->paginate(10);
 		$listData = $list->all();
 		foreach ($listData as $key => $value) {

--- a/application/index/controller/Profile.php
+++ b/application/index/controller/Profile.php
@@ -35,7 +35,7 @@ class Profile extends Controller{
 				$list = Db::name('shares')
 				->where('owner',$userId)
 				->where('type',"public")
-				->order('id DESC')
+				->order('share_time DESC')
 				->paginate(10);
 				break;
 			case 'hot':
@@ -49,7 +49,7 @@ class Profile extends Controller{
 				$list = Db::name('shares')
 				->where('owner',$userId)
 				->where('type',"public")
-				->order('id DESC')
+				->order('share_time DESC')
 				->paginate(10);
 				break;
 		}

--- a/application/index/controller/Share.php
+++ b/application/index/controller/Share.php
@@ -178,7 +178,7 @@ class Share extends Controller{
 		}
 		$userInfo = $this->userObj->getInfo();
 		$groupData =  $this->userObj->getGroupData();
-		$list = Db::name('shares')->where('owner',$this->userObj->uid)->paginate(10);
+		$list = Db::name('shares')->where('owner',$this->userObj->uid)->order('share_time DESC')->paginate(30);
 		$listData = $list->all();
 		foreach ($listData as $key => $value) {
 			if($value["source_type"]=="file"){

--- a/application/index/model/AdminHandler.php
+++ b/application/index/model/AdminHandler.php
@@ -519,7 +519,7 @@ class AdminHandler extends Model{
 
 	public function listShare(){
 		$pageSize = !cookie('?pageSize') ? 10 : cookie('pageSize');
-		$orderType = empty(cookie('orderMethodShare')) ? "id DESC" : cookie('orderMethodShare');
+		$orderType = empty(cookie('orderMethodShare')) ? "share_time DESC" : cookie('orderMethodShare');
 		$this->pageData = Db::name("shares")
 		->where(function ($query) {
 			if(!empty(cookie('shareSearch'))){


### PR DESCRIPTION
显示分享文件列表时根据分享时间倒序排列，最新分享的文件显示在最前，因为分享顺序并不一定按照文件上传顺序决定。